### PR TITLE
add X-OADA-IGNORE-LINKS header

### DIFF
--- a/oada-core/http-handler/oada-srvc-http-handler/resources.js
+++ b/oada-core/http-handler/oada-srvc-http-handler/resources.js
@@ -485,6 +485,8 @@ router.put('/*', async function putResource (req, res, next) {
         .then(bodyid => {
             trace('RESOURCE EXISTS', req.oadaGraph)
             trace('RESOURCE EXISTS', req.resourceExists)
+            let ignoreLinks =
+                (req.get('x-oada-ignore-links') || '').toLowerCase() == 'true'
             return requester.send(
                 {
                     connection_id: req.id,
@@ -499,7 +501,8 @@ router.put('/*', async function putResource (req, res, next) {
                     client_id: req.user['client_id'],
                     contentType: req.get('content-type'),
                     bodyid: bodyid,
-                    'if-match': req.get('if-match')
+                    'if-match': req.get('if-match'),
+                    ignoreLinks
                 },
                 config.get('kafka:topics:writeRequest')
             )

--- a/oada-core/write-handler/oada-srvc-write-handler/write_handler.js
+++ b/oada-core/write-handler/oada-srvc-write-handler/write_handler.js
@@ -117,7 +117,8 @@ function handleReq (req, msg) {
         if (path.length > 0) {
           // TODO: This is gross
           let ppath = Array.from(path)
-          method = (id, obj) => resources.deletePartialResource(id, ppath, obj)
+          method = (id, obj, checkLinks) =>
+            resources.deletePartialResource(id, ppath, obj)
           body = null
           changeType = 'delete'
         } else {
@@ -215,7 +216,7 @@ function handleReq (req, msg) {
       // Update rev of meta?
       obj['_meta']['_rev'] = rev
 
-      return Promise.resolve(method(id, obj))
+      return Promise.resolve(method(id, obj, !req.ignoreLinks))
         .then(orev => ({ rev, orev, changeId }))
         .tap(() => trace('method', Date.now() / 1000 - beforeMethod))
     })


### PR DESCRIPTION
This pull request adds `X-OADA-IGNORE-LINKS` header. When a PUT request is issued, the server checks whether the document contains any links. By setting `X-OADA-IGNORE-LINKS` to `true`, you can disable this check and potentially reduce the server load. This is useful for batch PUT requests. This pull request does not affect existing client codes.